### PR TITLE
Fix for timeout being prolonged

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,22 +93,21 @@ func main() {
 	}
 
 	emulatorBootDone := false
-	elapsedTime := int64(0)
+	startTime := time.Now()
 
 	for !emulatorBootDone {
+		log.Printf("> Checking if device booted...")
 		if emulatorBootDone, err = adb.IsDeviceBooted(config.EmulatorSerial); err != nil {
 			failf("Failed to check emulator boot status, error: %s", err)
 		} else if emulatorBootDone {
 			break
 		}
 
-		if elapsedTime >= timeout {
-			failf("Waiting for emulator boot timed out after %d seconds", config.BootTimeout)
+		if time.Now().Sub(startTime) >= time.Duration(timeout)*time.Second {
+			failf("Waiting for emulator boot timed out after %d seconds", timeout)
 		}
 
-		log.Printf("> Checking if device booted...")
 		time.Sleep(5 * time.Second)
-		elapsedTime += 5
 	}
 
 	if err := adb.UnlockDevice(config.EmulatorSerial); err != nil {

--- a/step.yml
+++ b/step.yml
@@ -31,7 +31,7 @@ inputs:
       description: |
         Emulator with the given serial will be checked if booted, or wait for it to boot.
       is_required: true
-  - boot_timeout: "180"
+  - boot_timeout: "300"
     opts:
       title: "Waiting timeout (secs)"
       summary: Maximum time to wait for emulator to boot


### PR DESCRIPTION
```
Waiting for emulator boot timed out after %!d(string=600) seconds
|                                                                              |
+---+---------------------------------------------------------------+----------+
| x | wait-for-android-emulator (exit code: 1)                      | 23.4 min |
+---+---------------------------------------------------------------+----------+

```

- Fixed string feeded into int printf
- Fixed timeout being prolonged twice (do not underestimate the overhead of adb)
- Reorganized the code to make it do what it prints
- The default timeout is extended to minimize breakage for users on the 3m default