### PR TITLE
Remove unused workflow

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2,6 +2,16 @@ format_version: "11"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 workflows:
+  check:
+    steps:
+    - git::https://github.com/bitrise-steplib/steps-check.git:
+
+  e2e:
+    steps:
+      - git::https://github.com/bitrise-steplib/steps-check.git:
+          inputs:
+            - workflow: e2e
+
   sample:
     steps:
     - avd-manager:
@@ -13,18 +23,3 @@ workflows:
         title: Stop Android Emulator
         inputs:
         - content: pkill -f qemu-system-i386
-
-  check:
-    steps:
-    - git::https://github.com/bitrise-steplib/steps-check.git:
-
-  e2e:
-    steps:
-      - git::https://github.com/bitrise-steplib/steps-check.git:
-          inputs:
-            - workflow: e2e
-
-  test:
-    before_run:
-    - check
-    - e2e


### PR DESCRIPTION
### Checklist

- [X] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context

Remove old validation workflows that were used in the old CI setup. These are not used anymore and only `check` and `e2e` are needed.

Part of https://bitrise.atlassian.net/browse/STEP-1144
